### PR TITLE
allow setting of Deluge address via environment variable DELUGE_HOST

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:alpine
+RUN pip install deluge-client prometheus_client
+COPY ./deluge_exporter.py /deluge_exporter.py
+EXPOSE 9354
+ENTRYPOINT ["/usr/local/bin/python", "/deluge_exporter.py"]

--- a/deluge_exporter.py
+++ b/deluge_exporter.py
@@ -213,7 +213,8 @@ class DelugeCollector(object):
       self.rpc_user, self.rpc_password = f.readline().strip().split(':')[:2]
 
   def collect(self):
-    client = DelugeRPCClient('127.0.0.1', self.rpc_port, self.rpc_user, self.rpc_password)
+    deluge_host = os.environ.get('DELUGE_HOST', '127.0.0.1')
+    client = DelugeRPCClient(deluge_host, self.rpc_port, self.rpc_user, self.rpc_password)
     client.connect()
 
     libtorrent_status_metrics = get_libtorrent_status_metrics_meta()


### PR DESCRIPTION
add Dockerfile

Run it like this:
```
docker run -e "DELUGE_HOST=172.17.0.1" -v /etc/deluge:/root/.config/deluge/ -p 9354:9354 registry.example.com/deluge_exporter:latest
```