### PR TITLE
added deluge 2.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# idea
+.idea/*
+
+# example
+example/*
+
+# env
+.env

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ It currently requires passing the deluge config directory into the container, [f
 docker run -e "DELUGE_HOST=172.17.0.1" -v /etc/deluge:/root/.config/deluge/ -p 9354:9354 tobbez/deluge_exporter:latest
 ```
 
+You probably need to [enable remote connections](https://dev.deluge-torrent.org/wiki/UserGuide/ThinClient#EnableRemoteConnection)!
+
 ## Exported metrics
 
 | Name                                                  | Type    | Description                                                                                                                                                   |

--- a/deluge_exporter.py
+++ b/deluge_exporter.py
@@ -164,17 +164,17 @@ def get_libtorrent_status_metrics_meta():
       'help': 'The number of torrents tracked by the DHT at the moment.',
     },
 
-    'dht_estimated_global_nodes': {
-      'source': b'dht_global_nodes',
-      'type': GaugeMetricFamily,
-      'help': 'An estimation of the total number of nodes in the DHT network.',
-    },
+    # 'dht_estimated_global_nodes': {
+    #   'source': b'dht_global_nodes',
+    #   'type': GaugeMetricFamily,
+    #   'help': 'An estimation of the total number of nodes in the DHT network.',
+    # },
 
-    'dht_total_allocations': {
-      'source': b'dht_total_allocations',
-      'type': GaugeMetricFamily,
-      'help': 'The number of nodes allocated dynamically for a particular DHT lookup. This represents roughly the amount of memory used by the DHT.',
-    },
+    # 'dht_total_allocations': {
+    #   'source': b'dht_total_allocations',
+    #   'type': GaugeMetricFamily,
+    #   'help': 'The number of nodes allocated dynamically for a particular DHT lookup. This represents roughly the amount of memory used by the DHT.',
+    # },
 
     # 'peerlist_size': {
     #   'source': b'peerlist_size',


### PR DESCRIPTION
I needed to comment out two metrics, and most of the things come with a simple pip install (with deluge client 1.8).

I also added a note to a readme bcs easy to miss the remote connection enable flag.

I think if you redeploy the docker file this will work fine!