### PR TITLE
Convert config dir from environment to Path

### DIFF
--- a/deluge_exporter.py
+++ b/deluge_exporter.py
@@ -42,7 +42,7 @@ def get_deluge_config_dir():
 
 class DelugeCollector:
   def __init__(self):
-    deluge_config_dir = os.environ.get('DELUGE_CONFIG_DIR', get_deluge_config_dir())
+    deluge_config_dir = Path(os.environ.get('DELUGE_CONFIG_DIR', get_deluge_config_dir()))
     with (deluge_config_dir / 'core.conf').open() as f:
       while f.read(1) != '}':
         pass


### PR DESCRIPTION
When passing the `DELUGE_CONFIG_DIR` environment variable the exporter fails with

    Traceback (most recent call last):
      File "/opt/deluge_exporter/deluge_exporter.py", line 123, in <module>
        start_exporter()
      File "/opt/deluge_exporter/deluge_exporter.py", line 118, in start_exporter
        REGISTRY.register(DelugeCollector())
      File "/opt/deluge_exporter/deluge_exporter.py", line 46, in __init__
        with (deluge_config_dir / 'core.conf').open() as f:
    TypeError: unsupported operand type(s) for /: 'str' and 'str'

This is because `os.environ.get` returns a `str` instead of a `Path` object, which is needed to make the `/` path operation work.

This PR fixes this by converting the environment variable to a `Path` first.