### PR TITLE
Fix python to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.11-alpine
 RUN pip install deluge-client prometheus_client loguru && rm -rf /root/.cache/
 COPY ./deluge_exporter.py /deluge_exporter.py
 COPY ./libtorrent_metrics.json /libtorrent_metrics.json


### PR DESCRIPTION
Because 3.12 removes ssl.wrap_socket()

https://docs.python.org/3/whatsnew/3.12.html?highlight=ssl%20wrap_socket#ssl

Fixes #24 